### PR TITLE
 feat(auth): add JWT-based isAuthenticate middleware for route protection

### DIFF
--- a/backend/src/middlewares/isAuthenticate.js
+++ b/backend/src/middlewares/isAuthenticate.js
@@ -1,0 +1,21 @@
+import jwt from 'jsonwebtoken'
+import createError from 'http-errors';
+import envConfig from '../config/envConfig.js'
+const isAuthenticate = async (req, res, next) => {
+  try {
+    // check authHeader
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return next(createError(401, 'Authorization header missing or invalid'));
+    }
+    const token = authHeader.split(' ')[1];
+    // decodedToken 
+    const decodedToken = jwt.verify(token, envConfig.jwt_secret);
+    req.userId = decodedToken.userId;
+    next();
+  } catch (error) {
+    return next(createError(400, `Invalid Or Expired Token : ${error.message}`));
+  }
+}
+
+export default isAuthenticate;

--- a/backend/src/modules/user/user.routes.js
+++ b/backend/src/modules/user/user.routes.js
@@ -1,18 +1,22 @@
 import express from "express";
 const router = express.Router();
 import { registerUser, loginUser, changePassword, deleteAccount, forgetPassword, verifyOtp } from "./user.controller.js";
-
+import isAuthenticate from "../../middlewares/isAuthenticate.js";
 // 1. register 
 router.post('/auth/register', registerUser);
 // 2. loginUser
 router.post('/auth/login', loginUser);
 // 6. verify top
 router.post('/auth/verify-otp', verifyOtp);
+
 // 3. change-password 
-router.post('/users/change-password', changePassword)
+router.post('/users/change-password', isAuthenticate, changePassword)
 // 4. deleteAccount
-router.get('/users/me', deleteAccount);
+router.get('/users/me', isAuthenticate, deleteAccount);
+
+
 // 5. forgetPassword 
+// No auth middleware here — because user is not logged in
 router.get('/users/forget-password', forgetPassword);
 
 // exports routes 


### PR DESCRIPTION
- Implemented `isAuthenticate` middleware to validate JWT tokens from the Authorization header.
- Extracts user ID from decoded token and attaches it to `req.userId`.
- Returns proper HTTP 401 errors for missing or invalid tokens.
- This middleware will be used to protect authenticated routes across the application.
