### PR TITLE
feat(auth): implement change password API for authenticated users

### DIFF
--- a/backend/src/modules/user/user.validation.js
+++ b/backend/src/modules/user/user.validation.js
@@ -9,13 +9,34 @@ const registerUserSchema = Joi.object({
 
 // loginUserSchema
 const loginUserSchema = Joi.object({
-  email:Joi.string().email().required(),
-  password:Joi.string().min(6).required()
+  email: Joi.string().email().required(),
+  password: Joi.string().min(6).required()
 })
 
 // otpVerificationSchema 
 const otpVerificationSchema = Joi.object({
-  email:Joi.string().email().required(),
-  otp:Joi.string().min(6).required(),
+  email: Joi.string().email().required(),
+  otp: Joi.string().min(6).required(),
 })
-export { registerUserSchema ,loginUserSchema,otpVerificationSchema};
+
+// currentPassword, newPassword, confirmNewPassword
+const changePasswordSchema = Joi.object({
+  currentPassword: Joi.string().min(6).required()
+    .messages({
+      'string.empty': 'Current password is required.',
+      'string.min': 'Current password must be at least 6 characters.'
+    }),
+  newPassword: Joi.string().min(6).required()
+    .messages({
+      'string.empty': 'New password is required.',
+      'string.min': 'New password must be at least 6 characters.'
+    }),
+  confirmNewPassword: Joi.string().valid(Joi.ref('newPassword')).required()
+    .messages({
+      'any.only': 'Confirm new password must match new password.',
+      'string.empty': 'Confirm new password is required.'
+    })
+})
+
+
+export { registerUserSchema, loginUserSchema, otpVerificationSchema,changePasswordSchema };


### PR DESCRIPTION
- Added a secure endpoint for users to change their password after authentication.
- Validates current password before allowing update to a new password.
- Ensures new password is hashed using bcrypt before saving to the database.
- Returns appropriate success and error responses for various failure cases (e.g., incorrect current password, validation errors).
- Middleware `isAuthenticate` is used to protect the route and extract user ID.
