### PR TITLE
 feat(auth): implement forget password flow with email reset link

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -35,14 +35,15 @@ jobs:
             USER_EMAIL_PASSWORD=${{secrets.USER_EMAIL_PASSWORD}}
             JWT_SECRET=${{secrets.JWT_SECRET}}
             JWT_TOKEN_EXPIRES_IN=${{secrets.JWT_TOKEN_EXPIRES_IN}}
+            CLIENT_URL=${{secrets.CLIENT_URL}}
             
       #frontend
-      # - name: Build and push Frontend image
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     context: ./frontend
-      #     file: ./frontend/Dockerfile
-      #     push: true
-      #     tags: ashukr321/peopledesk-frontend:latest
-      #     build-args: |
-      #       FRONTEND_PORT=${{secrets.FRONTEND_PORT}}
+      - name: Build and push Frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ashukr321/peopledesk-frontend:latest
+          build-args: |
+            FRONTEND_PORT=${{secrets.FRONTEND_PORT}}

--- a/backend/src/config/envConfig.js
+++ b/backend/src/config/envConfig.js
@@ -8,7 +8,8 @@ const envConfig = Object.freeze({
   user_email: process.env.USER_EMAIL,
   user_email_password: process.env.USER_EMAIL_PASSWORD,
   jwt_secret: process.env.JWT_SECRET,
-  jwt_token_expires_in: process.env.JWT_TOKEN_EXPIRES_IN
+  jwt_token_expires_in: process.env.JWT_TOKEN_EXPIRES_IN,
+  client_url:process.env.CLIENT_URL
 });
 
 export default envConfig;

--- a/backend/src/mailTemplates/forgetPassword.html
+++ b/backend/src/mailTemplates/forgetPassword.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>forget Password</title>
+</head>
+<body>
+  
+</body>
+</html>

--- a/backend/src/mailTemplates/resetPassword.html
+++ b/backend/src/mailTemplates/resetPassword.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset Password</title>
+</head>
+<body>
+  
+</body>
+</html>

--- a/backend/src/middlewares/globalErrorHandler.js
+++ b/backend/src/middlewares/globalErrorHandler.js
@@ -2,6 +2,7 @@ import createError from 'http-errors'
 
 // create globalErrorHandler Function 
 const globalErrorHandler = (err, req, res, next) => {
+
   if (!err.status) {
     const err = createError(500, "Internal Server Error");
     return next(err);

--- a/backend/src/modules/user/user.model.js
+++ b/backend/src/modules/user/user.model.js
@@ -29,6 +29,8 @@ const userSchema = new mongoose.Schema({
   otpExpiresAt: {
     type: Date,
   },
+  resetPasswordExpires:Date,
+
   timezone: {
     type: String,
   }

--- a/backend/src/modules/user/user.routes.js
+++ b/backend/src/modules/user/user.routes.js
@@ -1,23 +1,29 @@
 import express from "express";
 const router = express.Router();
-import { registerUser, loginUser, changePassword, deleteAccount, forgetPassword, verifyOtp } from "./user.controller.js";
+import { registerUser, loginUser, changePassword, deleteAccount, forgetPassword, resetPassword, verifyOtp } from "./user.controller.js";
 import isAuthenticate from "../../middlewares/isAuthenticate.js";
+
 // 1. register 
 router.post('/auth/register', registerUser);
+
 // 2. loginUser
 router.post('/auth/login', loginUser);
-// 6. verify top
+
+// 3. verify top
 router.post('/auth/verify-otp', verifyOtp);
 
-// 3. change-password 
+// 4. change-password 
 router.post('/users/change-password', isAuthenticate, changePassword)
-// 4. deleteAccount
-router.get('/users/me', isAuthenticate, deleteAccount);
-
 
 // 5. forgetPassword 
 // No auth middleware here — because user is not logged in
-router.get('/users/forget-password', forgetPassword);
+router.post('/users/forget-password', forgetPassword);
+
+// 6 resetPassword
+router.put('/users/reset-password', resetPassword);
+
+// 7. deleteAccount
+router.get('/users/me', isAuthenticate, deleteAccount);
 
 // exports routes 
 export default router;

--- a/backend/src/modules/user/user.validation.js
+++ b/backend/src/modules/user/user.validation.js
@@ -38,5 +38,9 @@ const changePasswordSchema = Joi.object({
     })
 })
 
+// forgetPasswordSchema 
+const forgetPasswordSchema = Joi.object({
+  email:Joi.string().email().required()
+})
 
-export { registerUserSchema, loginUserSchema, otpVerificationSchema,changePasswordSchema };
+export { registerUserSchema, loginUserSchema, otpVerificationSchema,changePasswordSchema,forgetPasswordSchema};

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const page = () => {
+  return (
+    <div className='flex justify-center items-center text-center text-3xl h-screen bg-black'>
+      <h1 className='text-white font-bold'>Reset password</h1>
+    </div>
+  )
+}
+
+export default page


### PR DESCRIPTION
- Added forget password API to handle user reset requests
- Validates user email and checks if the account exists
- Generates a JWT-based reset token with 1-hour expiry
- Stores reset token expiration timestamp in the database
- Composes and sends password reset email with a secure link
- Utilized a custom HTML template for reset email content
- Added proper error handling for user and mail failures
